### PR TITLE
feat(memory): add Redis and Postgres KVMemory adapters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,12 @@
         "@anthropic-ai/sdk": "^0.39.0",
         "@biomejs/biome": "^2.3.10",
         "@types/node": "^22.0.0",
+        "@types/pg": "^8.16.0",
         "ai": "^6.0.0",
         "husky": "^9.1.7",
+        "ioredis": "^5.8.2",
         "openai": "^4.104.0",
+        "pg": "^8.16.3",
         "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "ultracite": "^6.5.0",
@@ -23,7 +26,9 @@
       "peerDependencies": {
         "@anthropic-ai/sdk": "^0.20.0",
         "ai": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-        "openai": "^4.0.0"
+        "ioredis": "^5.0.0",
+        "openai": "^4.0.0",
+        "pg": "^8.0.0"
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
@@ -32,7 +37,13 @@
         "ai": {
           "optional": true
         },
+        "ioredis": {
+          "optional": true
+        },
         "openai": {
+          "optional": true
+        },
+        "pg": {
           "optional": true
         }
       }
@@ -747,6 +758,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/@ioredis/commands": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.4.0.tgz",
+      "integrity": "sha512-aFT2yemJJo+TZCmieA7qnYGQooOS7QfNmYrzGtsYd3g9j5iDP8AimYYAesf79ohjbLG12XxC4nG5DyEnC88AsQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
@@ -1162,6 +1180,18 @@
         "form-data": "^4.0.4"
       }
     },
+    "node_modules/@types/pg": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
     "node_modules/@vercel/oidc": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.5.tgz",
@@ -1410,6 +1440,16 @@
         "consola": "^3.2.3"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1496,6 +1536,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/dunder-proto": {
@@ -1890,6 +1940,31 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ioredis": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.8.2.tgz",
+      "integrity": "sha512-C6uC+kleiIMmjViJINWk80sOQw5lEzse1ZmvD+S/s8p8CWapftSaC+kocGTx6xrbrJ4WmYQGC08ffHLr6ToR6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.4.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1908,6 +1983,20 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
       "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2167,6 +2256,104 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2227,6 +2414,72 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2305,10 +2558,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2743,6 +3013,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,22 @@
     "./anthropic": {
       "types": "./dist/anthropic/index.d.ts",
       "import": "./dist/anthropic/index.js"
+    },
+    "./memory/redis": {
+      "types": "./dist/memory/redis.d.ts",
+      "import": "./dist/memory/redis.js"
+    },
+    "./memory/postgres": {
+      "types": "./dist/memory/postgres.d.ts",
+      "import": "./dist/memory/postgres.js"
     }
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.20.0",
     "ai": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
-    "openai": "^4.0.0"
+    "ioredis": "^5.0.0",
+    "openai": "^4.0.0",
+    "pg": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
@@ -46,7 +56,13 @@
     "ai": {
       "optional": true
     },
+    "ioredis": {
+      "optional": true
+    },
     "openai": {
+      "optional": true
+    },
+    "pg": {
       "optional": true
     }
   },
@@ -65,9 +81,12 @@
     "@anthropic-ai/sdk": "^0.39.0",
     "@biomejs/biome": "^2.3.10",
     "@types/node": "^22.0.0",
+    "@types/pg": "^8.16.0",
     "ai": "^6.0.0",
     "husky": "^9.1.7",
+    "ioredis": "^5.8.2",
     "openai": "^4.104.0",
+    "pg": "^8.16.3",
     "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "ultracite": "^6.5.0",

--- a/src/memory/postgres.test.ts
+++ b/src/memory/postgres.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { PostgresStore } from "./postgres";
+
+// Mock data storage
+const mockTables = new Map<string, Map<string, Record<string, unknown>>>();
+
+// Top-level regex patterns for the mock client
+const CREATE_TABLE_REGEX = /CREATE TABLE IF NOT EXISTS (\w+)/i;
+const SELECT_REGEX = /SELECT .+ FROM (\w+) WHERE key = \$1/i;
+const INSERT_REGEX = /INSERT INTO (\w+)/i;
+const DELETE_REGEX = /DELETE FROM (\w+) WHERE key = \$1/i;
+
+// Mock pg
+vi.mock("pg", () => {
+  return {
+    Pool: vi.fn().mockImplementation(() => ({
+      query: vi.fn(
+        (
+          text: string,
+          values?: unknown[]
+        ): Promise<{ rows: unknown[]; rowCount: number | null }> => {
+          const createMatch = text.match(CREATE_TABLE_REGEX);
+          if (createMatch) {
+            const tableName = createMatch[1];
+            if (!mockTables.has(tableName)) {
+              mockTables.set(tableName, new Map());
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+          }
+
+          const selectMatch = text.match(SELECT_REGEX);
+          if (selectMatch) {
+            const tableName = selectMatch[1];
+            const table = mockTables.get(tableName);
+            const key = values?.[0] as string;
+            const row = table?.get(key);
+
+            if (row) {
+              return Promise.resolve({ rows: [row], rowCount: 1 });
+            }
+            return Promise.resolve({ rows: [], rowCount: 0 });
+          }
+
+          const insertMatch = text.match(INSERT_REGEX);
+          if (insertMatch) {
+            const tableName = insertMatch[1];
+            let table = mockTables.get(tableName);
+            if (!table) {
+              table = new Map();
+              mockTables.set(tableName, table);
+            }
+
+            const key = values?.[0] as string;
+            const data = JSON.parse(values?.[1] as string);
+            const timestamp = values?.[2] as Date;
+            const metadata = values?.[3]
+              ? JSON.parse(values?.[3] as string)
+              : null;
+
+            // Check for existing entry (upsert behavior)
+            const existing = table.get(key);
+            const createdAt = existing
+              ? (existing.created_at as Date)
+              : timestamp;
+
+            table.set(key, {
+              key,
+              data,
+              created_at: createdAt,
+              updated_at: timestamp,
+              metadata,
+            });
+
+            return Promise.resolve({ rows: [], rowCount: 1 });
+          }
+
+          const deleteMatch = text.match(DELETE_REGEX);
+          if (deleteMatch) {
+            const tableName = deleteMatch[1];
+            const table = mockTables.get(tableName);
+            const key = values?.[0] as string;
+            const existed = table?.delete(key) ?? false;
+
+            return Promise.resolve({ rows: [], rowCount: existed ? 1 : 0 });
+          }
+
+          return Promise.resolve({ rows: [], rowCount: 0 });
+        }
+      ),
+      end: vi.fn(() => Promise.resolve()),
+    })),
+  };
+});
+
+beforeEach(() => {
+  mockTables.clear();
+});
+
+test("PostgresStore: get returns null for missing key", async () => {
+  const store = new PostgresStore<string>();
+  const result = await store.get("nonexistent");
+  expect(result).toBeNull();
+});
+
+test("PostgresStore: set and get", async () => {
+  const store = new PostgresStore<{ value: number }>();
+
+  await store.set("key1", { value: 42 });
+
+  const entry = await store.get("key1");
+  expect(entry).not.toBeNull();
+  expect(entry?.data).toEqual({ value: 42 });
+  expect(entry?.createdAt).toBeGreaterThan(0);
+  expect(entry?.updatedAt).toBeGreaterThan(0);
+});
+
+test("PostgresStore: set with metadata", async () => {
+  const store = new PostgresStore<string>();
+
+  await store.set("key", "value", { source: "test", priority: 1 });
+
+  const entry = await store.get("key");
+  expect(entry?.metadata).toEqual({ source: "test", priority: 1 });
+});
+
+test("PostgresStore: update preserves createdAt, updates updatedAt", async () => {
+  const store = new PostgresStore<{ count: number }>();
+
+  await store.set("key", { count: 1 });
+  const first = await store.get("key");
+
+  // Wait a tiny bit to ensure different timestamp
+  await new Promise((r) => setTimeout(r, 5));
+
+  await store.set("key", { count: 2 });
+  const second = await store.get("key");
+
+  expect(second?.data.count).toBe(2);
+  expect(second?.createdAt).toBe(first?.createdAt);
+  expect(second?.updatedAt).toBeGreaterThanOrEqual(first?.updatedAt ?? 0);
+});
+
+test("PostgresStore: delete removes entry", async () => {
+  const store = new PostgresStore<string>();
+
+  await store.set("key", "value");
+  expect(await store.get("key")).not.toBeNull();
+
+  const deleted = await store.delete("key");
+  expect(deleted).toBe(true);
+  expect(await store.get("key")).toBeNull();
+});
+
+test("PostgresStore: delete returns false for missing key", async () => {
+  const store = new PostgresStore<string>();
+  const result = await store.delete("nonexistent");
+  expect(result).toBe(false);
+});
+
+test("PostgresStore: uses custom table name", async () => {
+  const store = new PostgresStore<string>({
+    tableName: "my_custom_table",
+  });
+
+  await store.set("key", "value");
+
+  // Verify the data is stored in the custom table
+  expect(mockTables.has("my_custom_table")).toBe(true);
+  expect(mockTables.has("cria_kv_store")).toBe(false);
+});
+
+test("PostgresStore: uses default table name", async () => {
+  const store = new PostgresStore<string>();
+
+  await store.set("key", "value");
+
+  expect(mockTables.has("cria_kv_store")).toBe(true);
+});
+
+test("PostgresStore: auto-creates table on first operation", async () => {
+  const store = new PostgresStore<string>();
+
+  // Table shouldn't exist yet
+  expect(mockTables.has("cria_kv_store")).toBe(false);
+
+  // First get should create table
+  await store.get("nonexistent");
+
+  expect(mockTables.has("cria_kv_store")).toBe(true);
+});
+
+test("PostgresStore: end closes the pool", async () => {
+  const store = new PostgresStore<string>();
+  await store.end();
+  // If no error, the test passes
+});

--- a/src/memory/postgres.ts
+++ b/src/memory/postgres.ts
@@ -1,0 +1,173 @@
+import type { PoolConfig } from "pg";
+import { Pool } from "pg";
+import type { KVMemory, MemoryEntry } from "./key-value";
+
+/**
+ * Configuration options for the Postgres store.
+ */
+export interface PostgresStoreOptions extends PoolConfig {
+  /**
+   * Table name for storing entries.
+   * The table will be created automatically if it doesn't exist.
+   * @default "cria_kv_store"
+   */
+  tableName?: string;
+
+  /**
+   * Whether to create the table on first use if it doesn't exist.
+   * @default true
+   */
+  autoCreateTable?: boolean;
+}
+
+/**
+ * Database row structure for the kv store table.
+ */
+interface KVRow {
+  key: string;
+  data: unknown;
+  created_at: Date;
+  updated_at: Date;
+  metadata: Record<string, unknown> | null;
+}
+
+/**
+ * Postgres-backed implementation of KVMemory.
+ *
+ * Plug-and-play adapter using node-postgres (pg). Just pass your connection options.
+ *
+ * The store will automatically create the required table if it doesn't exist.
+ *
+ * @template T - The type of data to store
+ *
+ * @example
+ * ```typescript
+ * import { PostgresStore } from "@fastpaca/cria/memory/postgres";
+ *
+ * // Connect using environment variables (PG* env vars)
+ * const store = new PostgresStore<{ content: string }>();
+ *
+ * // Connect with options
+ * const store = new PostgresStore<{ content: string }>({
+ *   connectionString: "postgres://user:pass@localhost/mydb",
+ * });
+ *
+ * await store.set("key-1", { content: "Hello" });
+ * const entry = await store.get("key-1");
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With custom table name
+ * const store = new PostgresStore<string>({
+ *   host: "localhost",
+ *   database: "myapp",
+ *   tableName: "my_app_memory",
+ * });
+ * ```
+ */
+export class PostgresStore<T = unknown> implements KVMemory<T> {
+  private readonly pool: Pool;
+  private readonly tableName: string;
+  private readonly autoCreateTable: boolean;
+  private tableCreated = false;
+
+  constructor(options: PostgresStoreOptions = {}) {
+    const { tableName, autoCreateTable, ...poolConfig } = options;
+
+    this.pool = new Pool(poolConfig);
+    this.tableName = tableName ?? "cria_kv_store";
+    this.autoCreateTable = autoCreateTable ?? true;
+  }
+
+  private async ensureTable(): Promise<void> {
+    if (this.tableCreated || !this.autoCreateTable) {
+      return;
+    }
+
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.tableName} (
+        key TEXT PRIMARY KEY,
+        data JSONB NOT NULL,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        metadata JSONB
+      )
+    `);
+
+    this.tableCreated = true;
+  }
+
+  async get(key: string): Promise<MemoryEntry<T> | null> {
+    await this.ensureTable();
+
+    const result = await this.pool.query<KVRow>(
+      `SELECT key, data, created_at, updated_at, metadata FROM ${this.tableName} WHERE key = $1`,
+      [key]
+    );
+
+    const row = result.rows[0];
+
+    if (row === undefined) {
+      return null;
+    }
+
+    return {
+      data: row.data as T,
+      createdAt: new Date(row.created_at).getTime(),
+      updatedAt: new Date(row.updated_at).getTime(),
+      ...(row.metadata && { metadata: row.metadata }),
+    };
+  }
+
+  async set(
+    key: string,
+    data: T,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    await this.ensureTable();
+
+    const now = new Date();
+
+    // Use UPSERT to handle both insert and update cases
+    // ON CONFLICT preserves created_at and updates updated_at
+    await this.pool.query(
+      `
+      INSERT INTO ${this.tableName} (key, data, created_at, updated_at, metadata)
+      VALUES ($1, $2, $3, $3, $4)
+      ON CONFLICT (key) DO UPDATE SET
+        data = EXCLUDED.data,
+        updated_at = EXCLUDED.updated_at,
+        metadata = EXCLUDED.metadata
+      `,
+      [
+        key,
+        JSON.stringify(data),
+        now,
+        metadata ? JSON.stringify(metadata) : null,
+      ]
+    );
+  }
+
+  async delete(key: string): Promise<boolean> {
+    await this.ensureTable();
+
+    const result = await this.pool.query(
+      `DELETE FROM ${this.tableName} WHERE key = $1`,
+      [key]
+    );
+
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  /**
+   * Close the connection pool.
+   * Call this when you're done using the store to clean up connections.
+   */
+  async end(): Promise<void> {
+    await this.pool.end();
+  }
+}
+
+// Re-export types for convenience
+export type { KVMemory, MemoryEntry } from "./key-value";

--- a/src/memory/redis.test.ts
+++ b/src/memory/redis.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, expect, test, vi } from "vitest";
+import { RedisStore } from "./redis";
+
+// Mock ioredis
+const mockData = new Map<string, string>();
+
+vi.mock("ioredis", () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      get: vi.fn((key: string) => Promise.resolve(mockData.get(key) ?? null)),
+      set: vi.fn((key: string, value: string) => {
+        mockData.set(key, value);
+        return Promise.resolve("OK");
+      }),
+      del: vi.fn((key: string) => {
+        const existed = mockData.has(key);
+        mockData.delete(key);
+        return Promise.resolve(existed ? 1 : 0);
+      }),
+      quit: vi.fn(() => Promise.resolve("OK")),
+    })),
+  };
+});
+
+beforeEach(() => {
+  mockData.clear();
+});
+
+test("RedisStore: get returns null for missing key", async () => {
+  const store = new RedisStore<string>();
+  const result = await store.get("nonexistent");
+  expect(result).toBeNull();
+});
+
+test("RedisStore: set and get", async () => {
+  const store = new RedisStore<{ value: number }>();
+
+  await store.set("key1", { value: 42 });
+
+  const entry = await store.get("key1");
+  expect(entry).not.toBeNull();
+  expect(entry?.data).toEqual({ value: 42 });
+  expect(entry?.createdAt).toBeGreaterThan(0);
+  expect(entry?.updatedAt).toBeGreaterThan(0);
+});
+
+test("RedisStore: set with metadata", async () => {
+  const store = new RedisStore<string>();
+
+  await store.set("key", "value", { source: "test", priority: 1 });
+
+  const entry = await store.get("key");
+  expect(entry?.metadata).toEqual({ source: "test", priority: 1 });
+});
+
+test("RedisStore: update preserves createdAt, updates updatedAt", async () => {
+  const store = new RedisStore<{ count: number }>();
+
+  await store.set("key", { count: 1 });
+  const first = await store.get("key");
+
+  // Wait a tiny bit to ensure different timestamp
+  await new Promise((r) => setTimeout(r, 5));
+
+  await store.set("key", { count: 2 });
+  const second = await store.get("key");
+
+  expect(second?.data.count).toBe(2);
+  expect(second?.createdAt).toBe(first?.createdAt);
+  expect(second?.updatedAt).toBeGreaterThanOrEqual(first?.updatedAt ?? 0);
+});
+
+test("RedisStore: delete removes entry", async () => {
+  const store = new RedisStore<string>();
+
+  await store.set("key", "value");
+  expect(await store.get("key")).not.toBeNull();
+
+  const deleted = await store.delete("key");
+  expect(deleted).toBe(true);
+  expect(await store.get("key")).toBeNull();
+});
+
+test("RedisStore: delete returns false for missing key", async () => {
+  const store = new RedisStore<string>();
+  const result = await store.delete("nonexistent");
+  expect(result).toBe(false);
+});
+
+test("RedisStore: uses custom prefix", async () => {
+  const store = new RedisStore<string>({
+    keyPrefix: "myapp:",
+  });
+
+  await store.set("key", "value");
+
+  // Verify the key is stored with prefix
+  expect(mockData.has("myapp:key")).toBe(true);
+  expect(mockData.has("cria:kv:key")).toBe(false);
+});
+
+test("RedisStore: uses default prefix", async () => {
+  const store = new RedisStore<string>();
+
+  await store.set("key", "value");
+
+  expect(mockData.has("cria:kv:key")).toBe(true);
+});
+
+test("RedisStore: disconnect calls quit", async () => {
+  const store = new RedisStore<string>();
+  await store.disconnect();
+  // If no error, the test passes
+});

--- a/src/memory/redis.ts
+++ b/src/memory/redis.ts
@@ -1,0 +1,154 @@
+import type { RedisOptions } from "ioredis";
+import Redis from "ioredis";
+import type { KVMemory, MemoryEntry } from "./key-value";
+
+/**
+ * Configuration options for the Redis store.
+ */
+export interface RedisStoreOptions extends RedisOptions {
+  /**
+   * Key prefix for all entries stored by this instance.
+   * Useful for namespacing multiple stores in the same Redis instance.
+   * @default "cria:kv:"
+   */
+  keyPrefix?: string;
+
+  /**
+   * TTL (time-to-live) in seconds for entries.
+   * If set, entries will automatically expire after this duration.
+   * @default undefined (no expiration)
+   */
+  ttlSeconds?: number;
+}
+
+/**
+ * Internal structure for storing entries in Redis.
+ * Stored as JSON string.
+ */
+interface StoredEntry<T> {
+  data: T;
+  createdAt: number;
+  updatedAt: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Redis-backed implementation of KVMemory.
+ *
+ * Plug-and-play adapter using ioredis. Just pass your connection options.
+ *
+ * @template T - The type of data to store
+ *
+ * @example
+ * ```typescript
+ * import { RedisStore } from "@fastpaca/cria/memory/redis";
+ *
+ * // Connect to localhost:6379
+ * const store = new RedisStore<{ content: string }>();
+ *
+ * // Connect with options
+ * const store = new RedisStore<{ content: string }>({
+ *   host: "redis.example.com",
+ *   port: 6379,
+ *   password: "secret",
+ * });
+ *
+ * await store.set("key-1", { content: "Hello" });
+ * const entry = await store.get("key-1");
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // With TTL and custom prefix
+ * const store = new RedisStore<string>({
+ *   keyPrefix: "myapp:memory:",
+ *   ttlSeconds: 3600, // 1 hour TTL
+ * });
+ * ```
+ */
+export class RedisStore<T = unknown> implements KVMemory<T> {
+  private readonly client: Redis;
+  private readonly prefix: string;
+  private readonly ttlSeconds?: number;
+
+  constructor(options: RedisStoreOptions = {}) {
+    const { keyPrefix, ttlSeconds, ...redisOptions } = options;
+
+    this.client = new Redis(redisOptions);
+    this.prefix = keyPrefix ?? "cria:kv:";
+
+    if (ttlSeconds !== undefined) {
+      this.ttlSeconds = ttlSeconds;
+    }
+  }
+
+  private prefixedKey(key: string): string {
+    return `${this.prefix}${key}`;
+  }
+
+  async get(key: string): Promise<MemoryEntry<T> | null> {
+    const raw = await this.client.get(this.prefixedKey(key));
+
+    if (raw === null) {
+      return null;
+    }
+
+    const stored = JSON.parse(raw) as StoredEntry<T>;
+
+    return {
+      data: stored.data,
+      createdAt: stored.createdAt,
+      updatedAt: stored.updatedAt,
+      ...(stored.metadata && { metadata: stored.metadata }),
+    };
+  }
+
+  async set(
+    key: string,
+    data: T,
+    metadata?: Record<string, unknown>
+  ): Promise<void> {
+    const prefixedKey = this.prefixedKey(key);
+    const now = Date.now();
+
+    // Try to get existing entry to preserve createdAt
+    const existingRaw = await this.client.get(prefixedKey);
+    let createdAt = now;
+
+    if (existingRaw !== null) {
+      const existing = JSON.parse(existingRaw) as StoredEntry<T>;
+      createdAt = existing.createdAt;
+    }
+
+    const entry: StoredEntry<T> = {
+      data,
+      createdAt,
+      updatedAt: now,
+      ...(metadata && { metadata }),
+    };
+
+    const value = JSON.stringify(entry);
+
+    if (this.ttlSeconds !== undefined) {
+      await this.client.set(prefixedKey, value, "EX", this.ttlSeconds);
+    } else {
+      await this.client.set(prefixedKey, value);
+    }
+  }
+
+  async delete(key: string): Promise<boolean> {
+    const count = await this.client.del(this.prefixedKey(key));
+    return count > 0;
+  }
+
+  /**
+   * Disconnect from Redis.
+   * Call this when you're done using the store to clean up connections.
+   */
+  async disconnect(): Promise<void> {
+    await this.client.quit();
+  }
+}
+
+// Re-export types for convenience
+export type { KVMemory, MemoryEntry } from "./key-value";


### PR DESCRIPTION
- Add RedisStore: plug-and-play Redis adapter using ioredis
- Add PostgresStore: plug-and-play Postgres adapter using pg (node-postgres)
- Both adapters implement the KVMemory interface
- Auto table creation for Postgres, key prefixing and TTL support for Redis
- Optional peer dependencies: ioredis ^5.0.0, pg ^8.0.0
- Full test coverage with mocked clients