### PR TITLE
docs: revamp README and add core docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# Cria Docs
+
+Welcome to the Cria docs. This set is short by design - it focuses on the core concepts and the parts you'll use most often.
+
+## What is Cria?
+
+Cria is a JSX-based prompt renderer. You build prompts as components, assign
+priorities, and Cria fits the prompt to a token budget using strategies like
+truncation, omission, summarization, and vector search.
+
+- [Quickstart](quickstart.md)
+- [Concepts](concepts.md)
+- [Prompt structure](prompt-structure.md)
+- [Components](components.md)
+- [Strategies](strategies.md)
+- [Custom components](custom-components.md)
+- [Integrations](integrations.md)
+- [Memory and RAG](memory-and-rag.md)
+- [Recipes](recipes.md)
+
+## Runnable examples
+
+- [OpenAI Chat Completions](../examples/openai-chat-completions)
+- [OpenAI Responses](../examples/openai-responses)
+- [Anthropic](../examples/anthropic)
+- [Vercel AI SDK](../examples/ai-sdk)
+- [Summaries](../examples/summary)
+- [RAG](../examples/rag)

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,64 @@
+# Components
+
+Cria ships a small set of composable components. All are available from `@fastpaca/cria` unless noted.
+
+## Core building blocks
+
+- `Region`: groups children and sets priority for that subtree.
+- `Message`: semantic message with `messageRole` (system, user, assistant, tool).
+- `Truncate`: trims content to a token budget.
+- `Omit`: drops content entirely when shrinking.
+- `Last`: keeps only the last N children.
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">System rules</Message>
+  <Truncate budget={8000} priority={2}>{history}</Truncate>
+  <Omit priority={3}>{examples}</Omit>
+</Region>
+```
+
+Anything without a priority won't get truncated or managed in case you hit your budget, it will remain by default.
+
+## Semantic components
+
+- `ToolCall`: represents a tool invocation.
+- `ToolResult`: represents tool output.
+- `Reasoning`: stores reasoning text (mapped to supported outputs).
+
+These map cleanly to OpenAI and Anthropic tool formats via renderers.
+
+## Smart components
+
+### Summary
+
+Summarizes content when it is selected for reduction. Requires a store.
+
+```tsx
+import { InMemoryStore, Summary, type StoredSummary } from "@fastpaca/cria";
+
+const store = new InMemoryStore<StoredSummary>();
+
+<Summary id="history" store={store} priority={2}>
+  {conversationHistory}
+</Summary>
+```
+
+If you do not pass `summarize`, the nearest provider (`OpenAIProvider`, `AnthropicProvider`, or `AISDKProvider`) is used with a default prompt.
+
+### VectorSearch
+
+Injects vector search results at render time.
+
+```tsx
+<VectorSearch store={vectorStore} limit={5}>
+  {query}
+</VectorSearch>
+```
+
+Query sources, in order:
+1. Children text
+2. `query` prop
+3. `messages` prop (defaults to last user message)
+
+If no results are found, the default formatter throws. Provide a custom `formatResults` to handle empty results.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,68 @@
+# Concepts
+
+This page covers the core ideas behind Cria: how prompts become a tree, how
+priorities and strategies work, and how rendering fits a budget.
+
+## Prompt tree
+
+Cria turns a prompt into a tree of components. Each node can have:
+- **Children** (nested content)
+- **Priority** (lower number = more important)
+- **Strategy** (how to shrink when over budget)
+
+Think of it as a structured prompt IR:
+
+```
+Region (priority 0)
+  Message(system)
+  Message(user)
+  Region (priority 2)
+    ...history...
+```
+
+## Priorities
+
+Priorities are how Cria decides what to reduce first.
+
+| Priority | Typical use |
+| --- | --- |
+| 0 | System rules, safety requirements |
+| 1 | Current user request, tool outputs |
+| 2 | History, retrieved context |
+| 3 | Examples, optional context |
+
+## Strategies
+
+Strategies are functions that rewrite part of the tree when a budget is exceeded.
+
+Cria includes built-ins like `Truncate`, `Omit`, `Summary`, and `VectorSearch`, but
+you can attach your own strategy to any `Region` or custom component.
+
+## Renderers
+
+Renderers convert the prompt tree into the final output format:
+
+- Markdown string (default)
+- OpenAI Chat Completions / Responses
+- Anthropic Messages
+- Vercel AI SDK ModelMessage[]
+
+Renderers decide how semantic nodes like `Message`, `ToolCall`, and `ToolResult`
+map to provider formats.
+
+## Tokenizers and budgets
+
+`render()` takes a tokenizer and a token budget. If the prompt exceeds the
+budget, Cria applies strategies at the lowest priority until it fits.
+
+## Providers and context
+
+Provider components (`OpenAIProvider`, `AnthropicProvider`, `AISDKProvider`)
+attach model context to the tree so components like `Summary` can call a model
+without a custom summarize function.
+
+## Works everywhere
+
+JSX here is just syntax. Cria does not depend on the DOM or React, and runs in
+Node, Deno, Bun, and Edge runtimes. Adapters require their SDKs and supported
+runtimes.

--- a/docs/custom-components.md
+++ b/docs/custom-components.md
@@ -1,0 +1,60 @@
+# Custom components
+
+Cria components are just functions that return prompt elements. You can build
+reusable blocks the same way you build UI components.
+
+## Basic pattern
+
+```tsx
+import type { PromptElement } from "@fastpaca/cria";
+
+type SystemProps = { children: string };
+
+export function System({ children }: SystemProps): PromptElement {
+  return {
+    kind: "message",
+    role: "system",
+    priority: 0,
+    children: [children],
+  };
+}
+```
+
+## Composed component
+
+```tsx
+import { Message, Region } from "@fastpaca/cria";
+
+type ContextBlockProps = {
+  title: string;
+  children: string;
+};
+
+export function ContextBlock({ title, children }: ContextBlockProps) {
+  return (
+    <Region priority={2}>
+      <Message messageRole="assistant">
+        {title}\n{children}
+      </Message>
+    </Region>
+  );
+}
+```
+
+## Async components
+
+Components can be async. This is how `VectorSearch` works.
+
+```tsx
+export async function LoadContext() {
+  const text = await fetchContext();
+  return <Region priority={2}>{text}</Region>;
+}
+```
+
+## Notes for chat renderers
+
+Chat renderers output only `Message` nodes. If you want content to show up in
+Chat Completions or Anthropic, make sure it is inside a `Message`.
+
+Avoid nesting `Message` inside `Message` - keep messages as leaf nodes.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,74 @@
+# Integrations
+
+Cria ships plug-and-play renderers and provider components for common LLM SDKs.
+
+## OpenAI
+
+### Chat Completions
+
+```tsx
+import OpenAI from "openai";
+import { chatCompletions } from "@fastpaca/cria/openai";
+import { render } from "@fastpaca/cria";
+
+const client = new OpenAI();
+const messages = await render(prompt, { tokenizer, budget, renderer: chatCompletions });
+const response = await client.chat.completions.create({ model: "gpt-4o", messages });
+```
+
+### Responses (reasoning models)
+
+```tsx
+import { responses } from "@fastpaca/cria/openai";
+import { render } from "@fastpaca/cria";
+
+// Reuse your OpenAI client
+const input = await render(prompt, { tokenizer, budget, renderer: responses });
+const response = await client.responses.create({ model: "o3", input });
+```
+
+### Provider
+
+`OpenAIProvider` injects a model provider so components like `Summary` can
+summarize without a custom function.
+
+## Anthropic
+
+```tsx
+import Anthropic from "@anthropic-ai/sdk";
+import { anthropic } from "@fastpaca/cria/anthropic";
+import { render } from "@fastpaca/cria";
+
+const client = new Anthropic();
+const { system, messages } = await render(prompt, {
+  tokenizer,
+  budget,
+  renderer: anthropic,
+});
+const response = await client.messages.create({ model: "claude-sonnet-4-20250514", system, messages });
+```
+
+`AnthropicProvider` works like `OpenAIProvider` for components that need a model.
+
+## Vercel AI SDK
+
+```tsx
+import { renderer } from "@fastpaca/cria/ai-sdk";
+import { render } from "@fastpaca/cria";
+import { generateText } from "ai";
+
+const messages = await render(prompt, { tokenizer, budget, renderer });
+const { text } = await generateText({ model, messages });
+```
+
+`AISDKProvider` provides a model for `Summary` or other AI-backed components.
+
+`Messages` converts AI SDK UI messages into Cria elements, and
+`DEFAULT_PRIORITIES` gives a sensible starting point.
+
+## Related
+
+- [OpenAI Chat Completions](../examples/openai-chat-completions)
+- [OpenAI Responses](../examples/openai-responses)
+- [Anthropic](../examples/anthropic)
+- [Vercel AI SDK](../examples/ai-sdk)

--- a/docs/memory-and-rag.md
+++ b/docs/memory-and-rag.md
@@ -1,0 +1,53 @@
+# Memory and RAG
+
+Cria provides memory interfaces and adapters for summaries and retrieval.
+
+## Key-value memory
+
+`KVMemory` stores structured entries for components like `Summary`.
+
+```tsx
+import { InMemoryStore, Summary, type StoredSummary } from "@fastpaca/cria";
+
+const store = new InMemoryStore<StoredSummary>();
+
+<Summary id="history" store={store} priority={2}>
+  {conversationHistory}
+</Summary>
+```
+
+Adapters (subpath imports):
+
+```tsx
+import { RedisStore } from "@fastpaca/cria/memory/redis";
+import { PostgresStore } from "@fastpaca/cria/memory/postgres";
+```
+
+## Vector memory and RAG
+
+`VectorMemory` extends `KVMemory` with semantic search. Cria ships adapters for Chroma and Qdrant.
+
+```tsx
+import { ChromaClient } from "chromadb";
+import { ChromaStore } from "@fastpaca/cria/memory/chroma";
+import { VectorSearch } from "@fastpaca/cria";
+
+const chroma = new ChromaClient({ path: "http://localhost:8000" });
+const collection = await chroma.getOrCreateCollection({ name: "docs" });
+
+const store = new ChromaStore({ collection, embed: async (text) => embed(text) });
+
+const prompt = (
+  <VectorSearch store={store} limit={5} threshold={0.2}>
+    {query}
+  </VectorSearch>
+);
+```
+
+Notes:
+- `VectorSearch` resolves queries at render time.
+- If no results are found, the default formatter throws. Provide `formatResults` to handle empty results.
+
+## Related
+
+- [RAG example](../examples/rag)

--- a/docs/prompt-structure.md
+++ b/docs/prompt-structure.md
@@ -1,0 +1,116 @@
+# Prompt structure
+
+Cria prompts are trees. Each node can carry a priority and an optional strategy. When the prompt is over budget, Cria applies strategies at the lowest priority
+until it fits.
+
+## A minimal shape
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">System rules</Message>
+  <Message messageRole="user">Current request</Message>
+  <Truncate budget={8000} priority={2}>{history}</Truncate>
+  <Omit priority={3}>{examples}</Omit>
+</Region>
+```
+
+## Recommended layout
+
+Keep the highest-priority content at the top and put reducible sections behind
+clear boundaries.
+
+```
+[P0] System rules
+[P1] Current user request
+[P2] History / retrieval
+[P3] Examples / optional context
+```
+
+This layout makes it obvious what can shrink first and keeps critical instructions
+stable.
+
+## Role-based templates
+
+### Chat-first (balanced)
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">System rules</Message>
+  <Message messageRole="user">Current request</Message>
+  <Truncate budget={8000} priority={2}>{history}</Truncate>
+  <Omit priority={3}>{examples}</Omit>
+</Region>
+```
+
+### Tool-heavy (function calls)
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">Tool policy + safety</Message>
+  <Message messageRole="user">Task</Message>
+  <Truncate budget={6000} priority={2}>{toolHistory}</Truncate>
+  <Omit priority={3}>{debugNotes}</Omit>
+</Region>
+```
+
+### RAG-focused
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">Grounding rules</Message>
+  <Message messageRole="user">Question</Message>
+  <VectorSearch store={vectorStore} limit={5} priority={2}>
+    {query}
+  </VectorSearch>
+  <Truncate budget={6000} priority={2}>{history}</Truncate>
+</Region>
+```
+
+## Priorities
+
+Lower number means higher importance.
+
+| Priority | Use for |
+| --- | --- |
+| 0 | System rules, safety requirements |
+| 1 | Current request, tool results |
+| 2 | History, retrieved context |
+| 3 | Examples, optional context |
+
+## Strategies
+
+Strategies are how a node shrinks:
+
+- `Truncate` trims to a token budget.
+- `Omit` removes content entirely.
+- `Summary` replaces content with a summary.
+- `VectorSearch` inserts retrieval results at render time.
+- Custom strategy: pass a `strategy` function to any region.
+
+## Budgeting patterns
+
+- Keep system and current user messages at priority 0-1.
+- Put history and RAG context at priority 2.
+- Put examples or optional content at priority 3.
+- Use `Truncate` for long histories and `Summary` for long running sessions.
+
+## Fit errors
+
+If the prompt cannot be reduced further, `render()` throws `FitError`.
+Handle it and report the budget gap or adjust priorities.
+
+```tsx
+import { FitError } from "@fastpaca/cria";
+
+try {
+  await render(prompt, { tokenizer, budget: 2000 });
+} catch (error) {
+  if (error instanceof FitError) {
+    console.error(`Over budget by ${error.overBudgetBy} tokens`);
+  }
+}
+```
+
+## Async components
+
+Cria supports async components. `VectorSearch` is async and resolves at render time.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart
+
+Cria lets you build prompts as a small JSX tree and then fit them to a token budget.
+
+## Install
+
+```bash
+npm install @fastpaca/cria
+```
+
+## Configure the JSX runtime
+
+Add this to `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@fastpaca/cria"
+  }
+}
+```
+
+## Build your first prompt
+
+```tsx
+import { Message, Omit, Region, Truncate, render } from "@fastpaca/cria";
+
+const tokenizer = (text: string): number => Math.ceil(text.length / 4);
+
+const prompt = (
+  <Region priority={0}>
+    <Message messageRole="system">You are a helpful assistant.</Message>
+    <Truncate budget={4000} priority={2}>
+      {conversationHistory}
+    </Truncate>
+    <Omit priority={3}>{optionalExamples}</Omit>
+    <Message messageRole="user">{userQuestion}</Message>
+  </Region>
+);
+
+const output = await render(prompt, { tokenizer, budget: 8000 });
+```
+
+Use a real tokenizer (for example, `tiktoken`) for accurate counts.
+
+## Renderers
+
+By default `render()` returns a markdown string. Use a renderer to output
+OpenAI, Anthropic, or AI SDK message formats.
+
+- OpenAI: `@fastpaca/cria/openai`
+- Anthropic: `@fastpaca/cria/anthropic`
+- Vercel AI SDK: `@fastpaca/cria/ai-sdk`
+
+## Next steps
+
+- [Prompt structure](prompt-structure.md)
+- [Components](components.md)
+- [Integrations](integrations.md)
+
+## Status
+
+Shipping today:
+- Components: Region, Message, Truncate, Omit, Last, Summary, VectorSearch, ToolCall, ToolResult, Reasoning
+- Renderers: markdown, OpenAI Chat Completions, OpenAI Responses, Anthropic, AI SDK
+- Providers: OpenAIProvider, AnthropicProvider, AISDKProvider
+- Memory: InMemoryStore, Redis/Postgres adapters, Chroma/Qdrant adapters
+
+Planned or in progress:
+- Additional components (Examples, Code, Separators)
+- Next.js adapter
+- Observability (OpenTelemetry, snapshots, visualizer)

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,56 @@
+# Recipes
+
+Short patterns you can adapt to your app.
+
+## Budgeted history + optional examples
+
+```tsx
+<Region priority={0}>
+  <Message messageRole="system">System rules</Message>
+  <Truncate budget={6000} priority={2}>{history}</Truncate>
+  <Omit priority={3}>{examples}</Omit>
+  <Message messageRole="user">{question}</Message>
+</Region>
+```
+
+## Progressive summarization
+
+```tsx
+import { InMemoryStore, Summary, type StoredSummary } from "@fastpaca/cria";
+
+const store = new InMemoryStore<StoredSummary>();
+
+<Summary id="history" store={store} priority={2}>
+  {conversationHistory}
+</Summary>
+```
+
+## RAG at render time
+
+```tsx
+<VectorSearch store={vectorStore} limit={5}>
+  {query}
+</VectorSearch>
+```
+
+## Tool calls and results
+
+```tsx
+<Message messageRole="assistant">
+  <ToolCall toolCallId="weather" toolName="getWeather" input={{ city: "Paris" }} />
+</Message>
+<Message messageRole="tool">
+  <ToolResult toolCallId="weather" toolName="getWeather" output={{ temp: 72 }} />
+</Message>
+```
+
+## Reasoning replay for OpenAI Responses
+
+```tsx
+<Reasoning text={previousReasoning} />
+```
+
+## Related
+
+- [Summarization example](../examples/summary)
+- [RAG example](../examples/rag)

--- a/docs/strategies.md
+++ b/docs/strategies.md
@@ -1,0 +1,81 @@
+# Strategies
+
+Strategies control how a region shrinks when the prompt exceeds a token budget.
+
+## When strategies run
+
+During `render()`, Cria computes total tokens and applies strategies at the
+lowest priority. A strategy can:
+- Replace a node
+- Rewrite its children
+- Return `null` to remove it entirely
+
+## Strategy API
+
+```ts
+import type { Strategy } from "@fastpaca/cria";
+
+const myStrategy: Strategy = async ({
+  target,
+  tokenizer,
+  tokenString,
+  budget,
+  totalTokens,
+  iteration,
+  context,
+}) => {
+  // return a new PromptElement, the same one, or null
+  return target;
+};
+```
+
+Key inputs:
+- `target`: the node being reduced
+- `tokenizer` / `tokenString`: measure size
+- `budget`, `totalTokens`, `iteration`: current fit state
+- `context`: provider context injected by ancestor providers
+
+## Example: drop a region
+
+```ts
+import type { Strategy } from "@fastpaca/cria";
+
+const drop: Strategy = () => null;
+```
+
+## Example: simple truncation
+
+```ts
+import type { Strategy } from "@fastpaca/cria";
+
+const truncateToChars = (maxChars: number): Strategy => ({ target }) => {
+  const content = target.children
+    .map((child) => (typeof child === "string" ? child : ""))
+    .join("");
+
+  const trimmed = content.slice(0, maxChars);
+  return { ...target, children: [trimmed] };
+};
+```
+
+## Example: summarize with a model
+
+```ts
+import type { Strategy } from "@fastpaca/cria";
+
+const summarize: Strategy = async ({ target, tokenizer }) => {
+  const content = target.children
+    .map((child) => (typeof child === "string" ? child : ""))
+    .join("");
+
+  const summary = await callModel(`Summarize: ${content}`);
+  return { ...target, children: [summary], tokens: tokenizer(summary) };
+};
+```
+
+## Best practices
+
+- Keep strategies **deterministic** and **idempotent**.
+- Always reduce tokens (or return `null`) to avoid infinite loops.
+- Avoid heavy side effects; use context providers if you need model calls.
+- Use `Summary` when possible; it already handles persistence and providers.


### PR DESCRIPTION
## Summary
- Revamp README with a clearer landing-page flow, examples, integrations, and roadmap
- Add core docs pages: concepts, strategies, custom components, and supporting guides
- Normalize cross-links between docs and examples

## Testing
- Not run (docs-only changes)
