### PR TITLE
chore: simplify and refactor renderer code

### DIFF
--- a/examples/summary/main.tsx
+++ b/examples/summary/main.tsx
@@ -90,7 +90,7 @@ const prompt = (
 );
 
 // Render with a tight budget to trigger summarization
-const budget = 220; // Budget that triggers summarization (full content ~233 tokens)
+const budget = 240; // Budget that triggers summarization (full content ~243 tokens)
 const messages = await render(prompt, {
   tokenizer,
   budget,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -287,6 +287,16 @@ export { Summary } from "./summary";
 export type { ResultFormatter } from "./vector-search";
 export { VectorSearch } from "./vector-search";
 
+/**
+ * Intersperse a separator between elements of an array.
+ */
+function intersperse<T>(items: readonly T[], separator: T): T[] {
+  if (items.length === 0) {
+    return [];
+  }
+  return items.flatMap((item, i) => (i === 0 ? [item] : [separator, item]));
+}
+
 interface SeparatorProps {
   value?: string;
   priority?: number;
@@ -301,18 +311,9 @@ export function Separator({
   children = [],
 }: SeparatorProps): PromptElement {
   const normalized = children as PromptChildren;
-  const separated: PromptChildren = [];
-
-  normalized.forEach((child, index) => {
-    separated.push(child);
-    if (index < normalized.length - 1) {
-      separated.push(value);
-    }
-  });
-
   return {
     priority,
-    children: separated,
+    children: intersperse(normalized, value),
     ...(id && { id }),
   };
 }
@@ -333,14 +334,7 @@ export function Examples({
   children = [],
 }: ExamplesProps): PromptElement {
   const normalized = children as PromptChildren;
-  const withSeparators: PromptChildren = [];
-
-  normalized.forEach((child, index) => {
-    withSeparators.push(child);
-    if (index < normalized.length - 1) {
-      withSeparators.push(separator);
-    }
-  });
+  const withSeparators = intersperse(normalized, separator);
 
   const prefixed = title
     ? ([`${title}\n`, ...withSeparators] as PromptChildren)

--- a/src/components/summary.ts
+++ b/src/components/summary.ts
@@ -1,8 +1,8 @@
 import type { Child } from "../jsx-runtime";
 import type { KVMemory } from "../memory";
-import type { ModelProvider } from "../providers/types";
 import type {
   MaybePromise,
+  ModelProvider,
   PromptChildren,
   PromptElement,
   Strategy,

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,8 +70,9 @@ export {
   createSnapshotHooks,
   diffSnapshots,
   type Snapshot,
+  type SnapshotChild,
   type SnapshotDiff,
-  type SnapshotNode,
+  type SnapshotElement,
 } from "./snapshot";
 export type {
   CompletionMessage,

--- a/src/instrumentation/otel.ts
+++ b/src/instrumentation/otel.ts
@@ -1,4 +1,10 @@
-import { SpanStatusCode, context, type Attributes, type Span, type Tracer } from "@opentelemetry/api";
+import {
+  type Attributes,
+  context,
+  type Span,
+  SpanStatusCode,
+  type Tracer,
+} from "@opentelemetry/api";
 import type { RenderHooks } from "../render";
 import type { PromptElement } from "../types";
 
@@ -76,7 +82,8 @@ export function createOtelRenderHooks({
     },
 
     onFitError: (event) => {
-      const span = fitSpan ?? tracer.startSpan(spanName, undefined, context.active());
+      const span =
+        fitSpan ?? tracer.startSpan(spanName, undefined, context.active());
       setAttributes(span, {
         ...attributes,
         "cria.iteration": event.iteration,
@@ -95,24 +102,26 @@ export function createOtelRenderHooks({
 }
 
 function setElementAttributes(span: Span, element: PromptElement): void {
-  setAttributes(span, {
-    "cria.node.kind": element.kind ?? "region",
-    "cria.node.priority": element.priority,
-    ...(element.id ? { "cria.node.id": element.id } : {}),
-    ...(element.kind === "message" ? { "cria.node.role": element.role } : {}),
-    ...(element.kind === "tool-call"
-      ? {
-          "cria.node.tool_call_id": element.toolCallId,
-          "cria.node.tool_name": element.toolName,
-        }
-      : {}),
-    ...(element.kind === "tool-result"
-      ? {
-          "cria.node.tool_call_id": element.toolCallId,
-          "cria.node.tool_name": element.toolName,
-        }
-      : {}),
-  });
+  span.setAttribute("cria.node.kind", element.kind ?? "region");
+  span.setAttribute("cria.node.priority", element.priority);
+
+  if (element.id) {
+    span.setAttribute("cria.node.id", element.id);
+  }
+
+  switch (element.kind) {
+    case "message":
+      span.setAttribute("cria.node.role", element.role);
+      break;
+    case "tool-call":
+    case "tool-result":
+      span.setAttribute("cria.node.tool_call_id", element.toolCallId);
+      span.setAttribute("cria.node.tool_name", element.toolName);
+      break;
+    default:
+      // No additional attributes for other element kinds
+      break;
+  }
 }
 
 function setAttributes(span: Span, attrs: Attributes): void {

--- a/src/memory/qdrant/index.ts
+++ b/src/memory/qdrant/index.ts
@@ -36,6 +36,18 @@ interface QdrantPayload<T> {
 }
 
 /**
+ * Convert a Qdrant payload to a MemoryEntry.
+ */
+function payloadToEntry<T>(payload: QdrantPayload<T>): MemoryEntry<T> {
+  return {
+    data: payload.data,
+    createdAt: payload.createdAt,
+    updatedAt: payload.updatedAt,
+    ...(payload.metadata && { metadata: payload.metadata }),
+  };
+}
+
+/**
  * VectorMemory implementation backed by Qdrant.
  *
  * This adapter wraps a Qdrant collection and implements the VectorMemory interface,
@@ -102,16 +114,7 @@ export class QdrantStore<T = unknown> implements VectorMemory<T> {
 
     const payload = point.payload as QdrantPayload<T> | undefined;
 
-    if (!payload) {
-      return null;
-    }
-
-    return {
-      data: payload.data,
-      createdAt: payload.createdAt,
-      updatedAt: payload.updatedAt,
-      ...(payload.metadata && { metadata: payload.metadata }),
-    };
+    return payload ? payloadToEntry(payload) : null;
   }
 
   async set(
@@ -186,12 +189,7 @@ export class QdrantStore<T = unknown> implements VectorMemory<T> {
       results.push({
         key: String(point.id),
         score: point.score,
-        entry: {
-          data: payload.data,
-          createdAt: payload.createdAt,
-          updatedAt: payload.updatedAt,
-          ...(payload.metadata && { metadata: payload.metadata }),
-        },
+        entry: payloadToEntry(payload),
       });
     }
 

--- a/src/render.test.tsx
+++ b/src/render.test.tsx
@@ -218,8 +218,18 @@ test("render: fit decisions are deterministic", async () => {
 
   type EventLog =
     | { type: "start"; totalTokens: number }
-    | { type: "iteration"; iteration: number; priority: number; totalTokens: number }
-    | { type: "strategy"; iteration: number; priority: number; resultType: "node" | "null" }
+    | {
+        type: "iteration";
+        iteration: number;
+        priority: number;
+        totalTokens: number;
+      }
+    | {
+        type: "strategy";
+        iteration: number;
+        priority: number;
+        resultType: "node" | "null";
+      }
     | { type: "complete"; iterations: number; totalTokens: number };
 
   const runOnce = async (): Promise<{ result: string; events: EventLog[] }> => {

--- a/src/renderers/markdown.ts
+++ b/src/renderers/markdown.ts
@@ -1,4 +1,5 @@
 import type { PromptChildren, PromptElement, PromptRenderer } from "../types";
+import { safeStringify } from "./shared";
 
 export const markdownRenderer: PromptRenderer<string> = {
   name: "markdown",
@@ -24,11 +25,11 @@ function renderToMarkdown(element: PromptElement): string {
       return `<thinking>\n${element.text}\n</thinking>\n`;
     }
     case "tool-call": {
-      const inputText = safeJsonStringify(element.input);
+      const inputText = safeStringify(element.input, true);
       return `<tool_call name="${element.toolName}">\n${inputText}\n</tool_call>\n`;
     }
     case "tool-result": {
-      const outputText = safeJsonStringify(element.output);
+      const outputText = safeStringify(element.output, true);
       return `<tool_result name="${element.toolName}">\n${outputText}\n</tool_result>\n`;
     }
     default: {
@@ -43,19 +44,4 @@ function renderChildrenToMarkdown(children: PromptChildren): string {
     result += typeof child === "string" ? child : renderToMarkdown(child);
   }
   return result;
-}
-
-function safeJsonStringify(value: unknown): string {
-  if (typeof value === "string") {
-    return value;
-  }
-  if (value === undefined) {
-    return "undefined";
-  }
-
-  try {
-    return JSON.stringify(value, null, 2) ?? "null";
-  } catch {
-    return String(value);
-  }
 }

--- a/src/renderers/shared.ts
+++ b/src/renderers/shared.ts
@@ -1,0 +1,222 @@
+import type { PromptChildren, PromptElement } from "../types";
+
+/**
+ * Semantic representation of prompt content parts.
+ * Used by renderers to convert prompt trees into provider-specific formats.
+ */
+export type SemanticPart =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | { type: "tool-call"; toolCallId: string; toolName: string; input: unknown }
+  | {
+      type: "tool-result";
+      toolCallId: string;
+      toolName: string;
+      output: unknown;
+    };
+
+export type ToolCallPart = Extract<SemanticPart, { type: "tool-call" }>;
+export type ToolResultPart = Extract<SemanticPart, { type: "tool-result" }>;
+export type TextPart = Extract<SemanticPart, { type: "text" }>;
+export type ReasoningPart = Extract<SemanticPart, { type: "reasoning" }>;
+
+export type MessageElement = Extract<PromptElement, { kind: "message" }>;
+
+/**
+ * Collect all message nodes from the prompt tree.
+ */
+export function collectMessageNodes(
+  element: PromptElement,
+  acc: MessageElement[] = []
+): MessageElement[] {
+  if (element.kind === "message") {
+    acc.push(element);
+    return acc;
+  }
+
+  for (const child of element.children) {
+    if (typeof child !== "string") {
+      collectMessageNodes(child, acc);
+    }
+  }
+
+  return acc;
+}
+
+/**
+ * Extract semantic parts from prompt children.
+ */
+export function collectSemanticParts(children: PromptChildren): SemanticPart[] {
+  const parts: SemanticPart[] = [];
+
+  for (const child of children) {
+    if (typeof child === "string") {
+      if (child.length > 0) {
+        parts.push({ type: "text", text: child });
+      }
+      continue;
+    }
+
+    parts.push(...semanticPartsFromElement(child));
+  }
+
+  return parts;
+}
+
+/**
+ * Extract semantic parts from a single prompt element.
+ */
+export function semanticPartsFromElement(
+  element: PromptElement
+): SemanticPart[] {
+  switch (element.kind) {
+    case "tool-call":
+      return [
+        {
+          type: "tool-call",
+          toolCallId: element.toolCallId,
+          toolName: element.toolName,
+          input: element.input,
+        },
+      ];
+    case "tool-result":
+      return [
+        {
+          type: "tool-result",
+          toolCallId: element.toolCallId,
+          toolName: element.toolName,
+          output: element.output,
+        },
+      ];
+    case "reasoning":
+      return element.text.length === 0
+        ? []
+        : [{ type: "reasoning", text: element.text }];
+    case "message":
+      // Nested messages are ambiguous - skip
+      return [];
+    default:
+      return collectSemanticParts(element.children);
+  }
+}
+
+/**
+ * Coalesce adjacent text parts into single parts.
+ */
+export function coalesceTextParts(
+  parts: readonly SemanticPart[]
+): SemanticPart[] {
+  const result: SemanticPart[] = [];
+  let buffer = "";
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      buffer += part.text;
+      continue;
+    }
+
+    if (buffer.length > 0) {
+      result.push({ type: "text", text: buffer });
+      buffer = "";
+    }
+
+    result.push(part);
+  }
+
+  if (buffer.length > 0) {
+    result.push({ type: "text", text: buffer });
+  }
+
+  return result;
+}
+
+/**
+ * Safely stringify a value to JSON string.
+ * Returns string values directly, handles undefined, and catches JSON errors.
+ *
+ * @param value - The value to stringify
+ * @param pretty - If true, format with 2-space indentation (default: false)
+ */
+export function safeStringify(value: unknown, pretty = false): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (value === undefined) {
+    return "null";
+  }
+
+  try {
+    return (
+      (pretty ? JSON.stringify(value, null, 2) : JSON.stringify(value)) ??
+      "null"
+    );
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Categorized parts from a semantic parts list.
+ */
+export interface CategorizedParts {
+  textParts: TextPart[];
+  toolCallParts: ToolCallPart[];
+  toolResultParts: ToolResultPart[];
+  reasoningParts: ReasoningPart[];
+}
+
+/**
+ * Categorize semantic parts by type for easier processing.
+ */
+export function categorizeParts(
+  parts: readonly SemanticPart[]
+): CategorizedParts {
+  const textParts: TextPart[] = [];
+  const toolCallParts: ToolCallPart[] = [];
+  const toolResultParts: ToolResultPart[] = [];
+  const reasoningParts: ReasoningPart[] = [];
+
+  for (const part of parts) {
+    switch (part.type) {
+      case "text":
+        textParts.push(part);
+        break;
+      case "tool-call":
+        toolCallParts.push(part);
+        break;
+      case "tool-result":
+        toolResultParts.push(part);
+        break;
+      case "reasoning":
+        reasoningParts.push(part);
+        break;
+      default:
+        // Exhaustive check - TypeScript will error if a case is missing
+        break;
+    }
+  }
+
+  return { textParts, toolCallParts, toolResultParts, reasoningParts };
+}
+
+/**
+ * Extract text content from semantic parts.
+ * Optionally wraps reasoning parts in thinking tags.
+ */
+export function partsToText(
+  parts: readonly SemanticPart[],
+  options: { wrapReasoning?: boolean } = {}
+): string {
+  const { wrapReasoning = false } = options;
+  let result = "";
+
+  for (const part of parts) {
+    if (part.type === "text") {
+      result += part.text;
+    } else if (part.type === "reasoning" && wrapReasoning) {
+      result += `<thinking>\n${part.text}\n</thinking>\n`;
+    }
+  }
+
+  return result;
+}

--- a/src/snapshot.test.tsx
+++ b/src/snapshot.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { Omit, Region } from "./components";
-import { createSnapshot, createSnapshotHooks, diffSnapshots } from "./snapshot";
 import { render } from "./render";
+import { createSnapshot, createSnapshotHooks, diffSnapshots } from "./snapshot";
 
 const tokenizer = (text: string): number => text.length;
 

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -209,19 +209,16 @@ function snapshotElement(
     typeof child === "string" ? hashString(child) : child.hash
   );
 
+  const hasToolId =
+    element.kind === "tool-call" || element.kind === "tool-result";
+
   const hash = hashElement({
     kind: element.kind,
     priority: element.priority,
     role: element.kind === "message" ? element.role : undefined,
     text: element.kind === "reasoning" ? element.text : undefined,
-    toolCallId:
-      element.kind === "tool-call" || element.kind === "tool-result"
-        ? element.toolCallId
-        : undefined,
-    toolName:
-      element.kind === "tool-call" || element.kind === "tool-result"
-        ? element.toolName
-        : undefined,
+    toolCallId: hasToolId ? element.toolCallId : undefined,
+    toolName: hasToolId ? element.toolName : undefined,
     id: element.id,
     tokens,
     childHashes,


### PR DESCRIPTION
## Summary

- Extract shared utilities into `src/renderers/shared.ts` eliminating ~500 lines of duplicate code across OpenAI, Anthropic, and AI SDK renderers
- Simplify provider renderers with object lookups and functional patterns
- Fix critical bugs discovered during simplification (ordering, JSON validity)
- Reduce cognitive complexity and improve maintainability

## Changes

### New Shared Module (`src/renderers/shared.ts`)
- `collectMessageNodes()` - Collect message nodes from prompt tree
- `collectSemanticParts()` - Extract semantic parts from children
- `coalesceTextParts()` - Merge adjacent text parts
- `categorizeParts()` - Categorize parts by type
- `partsToText()` - Extract text content with optional reasoning wrapping
- `safeStringify()` - Safe JSON stringification
- Shared types: `SemanticPart`, `TextPart`, `ReasoningPart`, `ToolCallPart`, `ToolResultPart`

### Bug Fixes
- `safeStringify` now returns `"null"` (valid JSON) instead of `"undefined"`
- Preserve original text/reasoning/tool-call ordering in messages
- Include reasoning parts in Responses API messages
- Restore `providers/` re-exports to avoid breaking change

### Code Quality
- Replace if-else chains with object lookups
- Convert imperative loops to filter/map/join patterns
- Add `intersperse` helper to components
- Extract timestamp helpers in memory providers
- Reduce cognitive complexity in instrumentation

## Test plan

- [x] All 83 unit tests pass
- [x] Linting passes (`ultracite check`)
- [x] All 6 examples work correctly:
  - openai-responses
  - openai-chat-completions
  - anthropic
  - ai-sdk
  - rag
  - summary