### PR TITLE
fix(ci): add repository field for npm provenance verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Lightweight, fast, and tiny LLM Context & Memory layout renderer to enforce token budgets in long running agents.",
   "license": "MIT",
   "author": "seb@fastpaca.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fastpaca/cria"
+  },
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary
- Adds `repository` field to package.json for npm provenance verification
- Required for trusted publishing - npm validates that package.json repository URL matches the GitHub repo from the provenance attestation

## Test plan
- [ ] Merge to main and verify release workflow publishes successfully with provenance