### PR TITLE
chore: update docs after merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,7 @@ const messages = await cria
   .prompt(provider)
   .system("You are a research assistant.")
   .vectorSearch({ store, query: question, limit: 10 })
-  .providerScope(provider, (p) =>
-    p.summary(conversation, { store: memory }).last(conversation, { N: 20 })
-  )
+  .summary(conversation, { id: "history", store: memory, priority: 2 })
   .user(question)
   .render({ budget: 200_000 });
 ```
@@ -42,7 +40,7 @@ Start with **[Quickstart](docs/quickstart.md)**, then use **[Docs](docs/README.m
 
 - **Need RAG?** Call `.vectorSearch({ store, query })`.
 - **Need a summary for long conversations?** Use `.summary(...)`.
-- **Need to cap history but keep structure?** Use `Last(...)`.
+- **Need to cap history but keep structure?** Use `.last(...)`.
 - **Need to drop optional context when the context window is full?** Use `.omit(...)`.
 - **Using AI SDK?** Plug and play with `@fastpaca/cria/ai-sdk`!
 

--- a/docs/how-to/observability.md
+++ b/docs/how-to/observability.md
@@ -12,7 +12,7 @@ import { createProvider } from "@fastpaca/cria/openai";
 const hooks: RenderHooks = {
   onFitStart: (event) => console.log("fit start", event.totalTokens),
   onFitIteration: (event) => console.log("iteration", event.iteration, event.priority),
-  onStrategyApplied: (event) => console.log("applied", event.target.kind ?? "region"),
+  onStrategyApplied: (event) => console.log("applied", event.target.kind),
   onFitComplete: (event) => console.log("fit complete", event.totalTokens),
   onFitError: (event) => console.log("fit error", event.error.overBudgetBy),
 };

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -5,7 +5,7 @@ Cria treats prompts like a structured tree (similar to a UI component tree). Tha
 ## What Cria is
 
 - A fluent DSL for assembling prompt structure (`cria.prompt()`).
-- A small IR (intermediate representation): regions + semantic nodes (messages, tool messages, reasoning).
+- A small IR (intermediate representation): scopes + semantic nodes (messages, tool messages, reasoning).
 - A rendering layer: turn the same prompt tree into different provider payloads.
 - Optional compaction: when you set a token `budget`, strategies decide what can shrink first.
 


### PR DESCRIPTION
## Summary
- Fix README example: use correct `summary()` API with required `id` param, remove redundant `providerScope` when provider already bound at root
- Fix mental-model.md: change "regions" to "scopes" terminology
- Fix observability.md: remove outdated "region" fallback in example

## Test plan
- [x] Verified `summary()` signature requires `id: string` (builder.ts:431)
- [x] Verified provider bound via `.prompt(provider)` is inherited by strategies
- [x] Verified all scopes use `kind: "scope"` (no "region" in codebase)