### PR TITLE
feat(memory): support configurable summarizer prompt seeds

### DIFF
--- a/src/memory/summarizer.ts
+++ b/src/memory/summarizer.ts
@@ -38,9 +38,11 @@ export interface SummarizerPromptContext {
   existingSummary: string | null;
 }
 
-export type SummarizerPrompt = SummarizerPromptSeed | ((
-  context: SummarizerPromptContext
-) => SummarizerPromptSeed | Promise<SummarizerPromptSeed>);
+export type SummarizerPrompt =
+  | SummarizerPromptSeed
+  | ((
+      context: SummarizerPromptContext
+    ) => SummarizerPromptSeed | Promise<SummarizerPromptSeed>);
 
 export interface SummarizerOptions {
   history: ScopeContent<SummarizerProvider>;
@@ -194,10 +196,16 @@ export class Summarizer {
       summaryPrompt
     );
     const prompt = await this.makeBuilderFromSeed(seed);
-    const builder = this.applySummaryFlow(prompt, existingSummary, target.children);
+    const builder = this.applySummaryFlow(
+      prompt,
+      existingSummary,
+      target.children
+    );
 
     const summaryPromptTree = await builder.build();
-    const rendered = await render(summaryPromptTree, { provider: this.provider });
+    const rendered = await render(summaryPromptTree, {
+      provider: this.provider,
+    });
     const summaryText = await this.provider.completion(rendered);
 
     await this.store.set(summaryId, { content: summaryText }, summaryMetadata);

--- a/src/memory/summarizer.ts
+++ b/src/memory/summarizer.ts
@@ -253,7 +253,7 @@ export class Summarizer {
       return PromptBuilder.create(this.provider).system(seed);
     }
 
-    const nodes = await resolveScopeContent(seed, this.provider.codec);
+    const nodes = await this.resolveHistory(seed);
     return PromptBuilder.create(this.provider).merge(...nodes);
   }
 }

--- a/src/memory/summarizer.ts
+++ b/src/memory/summarizer.ts
@@ -32,15 +32,6 @@ export type StoredSummary = z.infer<typeof StoredSummarySchema>;
 
 export type SummarizerProvider = ModelProvider<unknown, ProviderToolIO>;
 
-const DEFAULT_SUMMARIZER_SYSTEM_PROMPT =
-  "You are a conversation summarizer. Create a concise summary that captures the key points and context needed to continue the conversation. Be brief but preserve essential information.";
-
-const DEFAULT_SUMMARIZER_INITIAL_INSTRUCTION =
-  "Summarize the conversation above.";
-
-const DEFAULT_SUMMARIZER_UPDATE_INSTRUCTION =
-  "Update the summary based on the previous summary and the conversation above.";
-
 type SummarizerPromptSeed = string | ScopeContent<SummarizerProvider>;
 
 export interface SummarizerPromptContext {
@@ -96,7 +87,9 @@ export class Summarizer {
     this.defaultId = config.id;
     this.provider = config.provider;
     this.defaultMetadata = config.metadata;
-    this.defaultPrompt = config.prompt ?? DEFAULT_SUMMARIZER_SYSTEM_PROMPT;
+    this.defaultPrompt =
+      config.prompt ??
+      "You are a conversation summarizer. Create a concise summary that captures the key points and context needed to continue the conversation. Be brief but preserve essential information.";
     this.messageRole = config.role ?? "system";
     this.priority = config.priority;
   }
@@ -238,8 +231,8 @@ export class Summarizer {
 
     builder = builder.user(
       existingSummary
-        ? DEFAULT_SUMMARIZER_UPDATE_INSTRUCTION
-        : DEFAULT_SUMMARIZER_INITIAL_INSTRUCTION
+        ? "Update the summary based on the previous summary and the conversation above."
+        : "Summarize the conversation above."
     );
 
     return builder;

--- a/tests/dsl/summary.test.ts
+++ b/tests/dsl/summary.test.ts
@@ -124,8 +124,7 @@ describe("summary helper", () => {
       id: "conv-existing",
       store,
       provider,
-      prompt:
-        "You are a strict summarizer. Return compact JSON.",
+      prompt: "You are a strict summarizer. Return compact JSON.",
     });
 
     const output = await summary.writeNow({
@@ -171,7 +170,9 @@ describe("summary helper", () => {
 
     expect(output).toBe("updated");
     expect(provider.lastRendered).toContain("system: Factory summary start");
-    expect(provider.lastRendered).toContain("user: Summarize the conversation above.");
+    expect(provider.lastRendered).toContain(
+      "user: Summarize the conversation above."
+    );
     expect(provider.lastRendered).toContain("user: User asked about billing.");
   });
 
@@ -193,7 +194,9 @@ describe("summary helper", () => {
     expect(output).toBe("updated");
     expect(provider.lastRendered).toContain("system: Seeded summary prompt");
     expect(provider.lastRendered).toContain("user: Need a recap.");
-    expect(provider.lastRendered).toContain("user: Summarize the conversation above.");
+    expect(provider.lastRendered).toContain(
+      "user: Summarize the conversation above."
+    );
   });
 
   test("writeNow prompt override wins over config prompt", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path";
 import { defineConfig } from "vitest/config";
 
-const srcPath = resolve(__dirname, "src");
+const srcPath = resolve(import.meta.dirname, "src");
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary
- add configurable summarizer prompt seeding via `prompt` on both `SummarizerConfig` and `SummarizerOptions`
- support three prompt modes: raw system string, prompt/builder seed, or callback factory based on `existingSummary`
- keep history + summarize/update instructions framework-owned and consistently appended after the seed
- narrow callback context to `existingSummary` only to avoid accidental history duplication

## Tests
- `npm test -- tests/dsl/summary.test.ts`
- added coverage for string override, callback factory, prompt builder seed, and per-call prompt precedence
